### PR TITLE
[Feat] 액세스 토큰 재발급 시 status 필드 추가

### DIFF
--- a/src/main/java/navik/global/auth/controller/AuthController.java
+++ b/src/main/java/navik/global/auth/controller/AuthController.java
@@ -11,6 +11,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import navik.global.apiPayload.ApiResponse;
 import navik.global.apiPayload.exception.code.GeneralSuccessCode;
+import navik.global.auth.dto.RefreshDTO;
+import navik.global.auth.dto.RefreshResponseDTO;
 import navik.global.auth.dto.TokenDTO;
 import navik.global.auth.service.AuthService;
 
@@ -22,16 +24,16 @@ public class AuthController implements AuthControllerDocs {
 	private final AuthService authService;
 
 	@PostMapping("/refresh")
-	public ApiResponse<String> reissue(@CookieValue("refresh_token") String refreshToken,
+	public ApiResponse<RefreshResponseDTO> reissue(@CookieValue("refresh_token") String refreshToken,
 		HttpServletResponse response) {
 
-		TokenDTO tokenDto = authService.reissue(refreshToken);
+		RefreshDTO refreshDTO = authService.reissue(refreshToken);
 
 		// Refresh Token Cookie 설정
-		ResponseCookie cookie = authService.createRefreshTokenCookie(tokenDto.getRefreshToken());
+		ResponseCookie cookie = authService.createRefreshTokenCookie(refreshDTO.tokenDTO().getRefreshToken());
 		response.addHeader("Set-Cookie", cookie.toString());
 
-		return ApiResponse.onSuccess(GeneralSuccessCode._OK, tokenDto.getAccessToken());
+		return ApiResponse.onSuccess(GeneralSuccessCode._OK, new RefreshResponseDTO(refreshDTO.tokenDTO().getAccessToken(),refreshDTO.status()));
 	}
 
 	@PostMapping("/logout")

--- a/src/main/java/navik/global/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/navik/global/auth/controller/AuthControllerDocs.java
@@ -8,12 +8,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import navik.global.apiPayload.ApiResponse;
+import navik.global.auth.dto.RefreshDTO;
+import navik.global.auth.dto.RefreshResponseDTO;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 public interface AuthControllerDocs {
 
 	@Operation(summary = "토큰 재발급", description = "Cookie에 있는 Refresh Token을 이용하여 새로운 Access Token을 발급합니다.")
-	ApiResponse<String> reissue(
+	ApiResponse<RefreshResponseDTO> reissue(
 		@Parameter(description = "Refresh Token (HttpOnly Cookie)", required = true) @CookieValue("refresh_token") String refreshToken,
 		HttpServletResponse response);
 

--- a/src/main/java/navik/global/auth/dto/RefreshDTO.java
+++ b/src/main/java/navik/global/auth/dto/RefreshDTO.java
@@ -1,0 +1,6 @@
+package navik.global.auth.dto;
+
+public record RefreshDTO(
+	TokenDTO tokenDTO,
+	String status) {
+}

--- a/src/main/java/navik/global/auth/dto/RefreshResponseDTO.java
+++ b/src/main/java/navik/global/auth/dto/RefreshResponseDTO.java
@@ -1,0 +1,7 @@
+package navik.global.auth.dto;
+
+public record RefreshResponseDTO(
+	String accessToken,
+	String status
+) {
+}

--- a/src/main/java/navik/global/auth/service/AuthService.java
+++ b/src/main/java/navik/global/auth/service/AuthService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import navik.global.apiPayload.exception.exception.GeneralException;
+import navik.global.auth.JwtUserDetails;
+import navik.global.auth.dto.RefreshDTO;
 import navik.global.auth.dto.TokenDTO;
 import navik.global.auth.exception.code.AuthErrorCode;
 import navik.global.auth.jwt.JwtTokenProvider;
@@ -33,7 +35,7 @@ public class AuthService {
 	private long accessTokenValidityInSeconds;
 
 	@Transactional
-	public TokenDTO reissue(String refreshToken) {
+	public RefreshDTO reissue(String refreshToken) {
 		// 1. Refresh Token 검증
 		jwtTokenProvider.validateToken(refreshToken, false);
 
@@ -60,7 +62,7 @@ public class AuthService {
 		redisRefreshToken.updateToken(tokenDto.getRefreshToken());
 		refreshTokenRepository.save(redisRefreshToken);
 
-		return tokenDto;
+		return new RefreshDTO(tokenDto,((JwtUserDetails)userDetails).getStatus());
 	}
 
 	@Transactional


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #156 

## 🔁 작업 내용

## 📸 스크린샷 (Optional)
<img width="714" height="230" alt="image" src="https://github.com/user-attachments/assets/1ba18608-b7f5-4cbf-bea2-912dffe351e1" />

## 👀 기타 더 이야기해볼 점 (Optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 토큰 갱신 엔드포인트의 응답 구조를 개선했습니다. 기존의 단순 토큰 문자열에서 액세스 토큰과 상태 정보를 모두 포함하는 구조화된 응답으로 변경되어 API 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->