### PR TITLE
[Hotfix] 게시글 삭제 관련 오류 수정

### DIFF
--- a/src/main/java/navik/domain/board/entity/Board.java
+++ b/src/main/java/navik/domain/board/entity/Board.java
@@ -1,5 +1,9 @@
 package navik.domain.board.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -46,6 +51,14 @@ public class Board extends BaseEntity {
 	@Column(name = "article_likes", nullable = false)
 	@Builder.Default
 	private Integer articleLikes = 0;
+
+	@OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<Comment> articleComments = new ArrayList<>();
+
+	@OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<BoardLike> boardLikes = new ArrayList<>();
 
 	public void updateBoard(String articleTitle, String articleContent) {
 		this.articleTitle = articleTitle;


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #197 

## 🔁 작업 내용
게시글 삭제 시 컬럼에 포함된 댓글 수, 좋아요 수 함께 삭제합니다

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능
* 게시판에서 댓글과 좋아요 데이터를 더욱 효율적으로 관리할 수 있는 개선사항이 추가되었습니다. 이제 게시판과 댓글, 좋아요 정보 간의 연관성이 강화되어 보다 안정적인 데이터 관리가 가능합니다. 특히 게시판을 삭제할 때 관련된 모든 댓글과 좋아요가 자동으로 함께 정리되어 시스템의 데이터 무결성을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->