### PR TITLE
[Hotfix]: 마이페이지 수정 / 포트폴리오 등록 오류 수정

### DIFF
--- a/src/main/java/navik/domain/portfolio/worker/PortfolioAnalysisWorkerProcessor.java
+++ b/src/main/java/navik/domain/portfolio/worker/PortfolioAnalysisWorkerProcessor.java
@@ -44,10 +44,16 @@ public class PortfolioAnalysisWorkerProcessor {
 		// 2) 분석 요청 및 KPI 점수 초기화
 		boolean success = isFallBacked ? processFallbackAnalysis(userId, portfolio, traceId) :
 			processNormalAnalysis(userId, portfolio, portfolioId, traceId);
-		if (!success) {return false;}
+		if (!success) {
+			return false;
+		}
 
-		portfolio.updateStatus(PortfolioStatus.COMPLETED);
 		eventPublisher.publishEvent(new KpiScoreUpdatedEvent(userId));
+
+		if (portfolio.getStatus() != PortfolioStatus.RETRY_REQUIRED) {
+			portfolio.updateStatus(PortfolioStatus.COMPLETED);
+		}
+
 		return true;
 	}
 

--- a/src/main/java/navik/domain/users/repository/UserDepartmentRepository.java
+++ b/src/main/java/navik/domain/users/repository/UserDepartmentRepository.java
@@ -3,6 +3,7 @@ package navik.domain.users.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,5 +13,8 @@ public interface UserDepartmentRepository extends JpaRepository<UserDepartment, 
 
 	@Query("SELECT ud.department.id FROM UserDepartment ud WHERE ud.user.id = :userId")
 	List<Long> findDepartmentIdsByUserId(Long userId);
-	void deleteAllByUserId(Long userId);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("DELETE FROM UserDepartment ud WHERE ud.user.id = :userId")
+	void deleteAllByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #230 

## 🔁 작업 내용
*  jpa에서 flush시점에 insert가 먼저 실행됨(DB unique제약 충돌)
* deleteAll 수정

* 포트폴리오 분석시 required 분기처리 제대로 되지 않고 항상 completed로 가는 문제 해결

## 📸 스크린샷 (Optional)
<img width="1056" height="509" alt="image" src="https://github.com/user-attachments/assets/3a04cdd1-69fc-488a-9f2f-b1b8f15a4d8a" />


## 👀 기타 더 이야기해볼 점 (Optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포트폴리오 분석 완료 상태 처리 개선: 필요시 재분석 요청 상태가 올바르게 유지됩니다.

* **리팩토링**
  * 사용자 부서 정보 삭제 처리 최적화: 데이터 일관성 및 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->