### PR TITLE
[Hotfix] 포트폴리오 저장시 kpi 카드 번호 불일치 문제

### DIFF
--- a/src/main/java/navik/domain/portfolio/ai/client/AiServerPortfolioAiClient.java
+++ b/src/main/java/navik/domain/portfolio/ai/client/AiServerPortfolioAiClient.java
@@ -27,6 +27,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 	private static final String FALLBACK_PATH_PREFIX = "/api/kpi/fallback/";
 
 	private static final Map<Long, String> JOB_NAME_MAP = Map.of(1L, "pm", 2L, "designer", 3L, "frontend", 4L, "backend");
+	private static final Map<Long, Long> KPI_OFFSET_MAP = Map.of(1L, 0L, 2L, 10L, 3L, 20L, 4L, 30L);
 
 	@Override
 	public String extractTextFromPdf(String fileUrl) {
@@ -50,7 +51,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 	@Override
 	public PortfolioAiDTO.AnalyzeResponse analyzePortfolio(String resumeText, Long jobId) {
 		try {
-			return aiWebClient.post()
+			PortfolioAiDTO.AnalyzeResponse response = aiWebClient.post()
 				.uri(ANALYZE_PATH_PREFIX + JOB_NAME_MAP.get(jobId))
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
@@ -59,6 +60,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 				.bodyToMono(PortfolioAiDTO.AnalyzeResponse.class)
 				.timeout(Duration.ofSeconds(30))
 				.block();
+			return response.withKpiIdOffset(KPI_OFFSET_MAP.get(jobId));
 		} catch (Exception e) {
 			throw new GeneralException(GeneralErrorCode.EXTERNAL_API_ERROR);
 		}
@@ -67,7 +69,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 	@Override
 	public PortfolioAiDTO.AnalyzeResponse analyzeAbilities(String resumeText, Long jobId) {
 		try {
-			return aiWebClient.post()
+			PortfolioAiDTO.AnalyzeResponse response = aiWebClient.post()
 				.uri(ABILITIES_PATH_PREFIX + JOB_NAME_MAP.get(jobId))
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
@@ -76,6 +78,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 				.bodyToMono(PortfolioAiDTO.AnalyzeResponse.class)
 				.timeout(Duration.ofSeconds(30))
 				.block();
+			return response.withKpiIdOffset(KPI_OFFSET_MAP.get(jobId));
 		} catch (Exception e) {
 			throw new GeneralException(GeneralErrorCode.EXTERNAL_API_ERROR);
 		}
@@ -85,7 +88,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 	public PortfolioAiDTO.AnalyzeResponse analyzeWithFallback(Long jobId, Integer qB1, Integer qB2, Integer qB3,
 		Integer qB4, Integer qB5) {
 		try {
-			return aiWebClient.post()
+			PortfolioAiDTO.AnalyzeResponse response = aiWebClient.post()
 				.uri(FALLBACK_PATH_PREFIX + JOB_NAME_MAP.get(jobId))
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
@@ -94,6 +97,7 @@ public class AiServerPortfolioAiClient implements PortfolioAiClient {
 				.bodyToMono(PortfolioAiDTO.AnalyzeResponse.class)
 				.timeout(Duration.ofSeconds(30))
 				.block();
+			return response.withKpiIdOffset(KPI_OFFSET_MAP.get(jobId));
 		} catch (Exception e) {
 			throw new GeneralException(GeneralErrorCode.EXTERNAL_API_ERROR);
 		}

--- a/src/main/java/navik/domain/portfolio/dto/PortfolioAiDTO.java
+++ b/src/main/java/navik/domain/portfolio/dto/PortfolioAiDTO.java
@@ -23,6 +23,16 @@ public class PortfolioAiDTO {
 	public record AnalyzeResponse(List<KpiScoreItem> scores, List<Abilities> abilities) {
 		public record KpiScoreItem(@JsonProperty("kpi_id") Long kpiId, @JsonProperty("kpi_name") String kpiName,
 								   Integer score, String basis) {
+			public KpiScoreItem withOffsetKpiId(long offset) {
+				return new KpiScoreItem(kpiId + offset, kpiName, score, basis);
+			}
+		}
+
+		public AnalyzeResponse withKpiIdOffset(long offset) {
+			List<KpiScoreItem> mappedScores = scores.stream()
+				.map(item -> item.withOffsetKpiId(offset))
+				.toList();
+			return new AnalyzeResponse(mappedScores, abilities);
 		}
 	}
 


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #257 

## 🔁 작업 내용
* fastapi 응답에 직무별 오프셋을 더해 kpi카드를 매핑하도록 수정했습니다. 
## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)