### PR TITLE
[Hotfix] 프로필 수정 시 전공 미선택 허용

### DIFF
--- a/src/main/java/navik/domain/users/service/UserCommandService.java
+++ b/src/main/java/navik/domain/users/service/UserCommandService.java
@@ -39,7 +39,7 @@ public class UserCommandService {
 
 		user.updateMyInfo(req.nickname(), req.isEntryLevel(), req.educationLevel());
 
-		if (req.departmentIds() != null) {
+		if (req.departmentIds() != null && !req.departmentIds().isEmpty()) {
 			userDepartmentRepository.deleteAllByUserId(userId);
 
 			List<UserDepartment> newDepartments = req.departmentIds()


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #281 

## 🔁 작업 내용
- 프로필 수정 시 전공 미선택을 허용합니다.

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 사용자 정보 업데이트 시 부서 정보가 없거나 비어있을 때 불필요한 부서 데이터 변경을 방지하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->