### PR TITLE
[Refactor] 채용공고 소비 멱등성 리팩토링

### DIFF
--- a/src/main/java/navik/domain/recruitment/listener/RecruitmentConsumer.java
+++ b/src/main/java/navik/domain/recruitment/listener/RecruitmentConsumer.java
@@ -114,6 +114,12 @@ public class RecruitmentConsumer
 			return;
 		}
 
+		if (recruitmentDTO.getPostId() == null) {
+			log.error("[RecruitmentConsumer] postId가 null입니다. recordId={}", recordId);
+			handleError(recordId);
+			return;
+		}
+
 		try {
 			String duplicateCheckKey = "RECRUITMENT:LOCK:" + recruitmentDTO.getPostId();
 			Boolean isAcquired = redisTemplate.opsForValue()
@@ -124,6 +130,8 @@ public class RecruitmentConsumer
 				if ("DONE".equals(currentStatus)) {
 					log.info("[RecruitmentConsumer] 이미 처리 완료된 공고입니다. (ACK 유실 방지)");
 					redisTemplate.opsForStream().acknowledge(receivedStreamKey, consumerGroupName, recordId);
+				} else if (currentStatus == null) {
+					log.warn("[RecruitmentConsumer] 락 키가 만료/삭제되었습니다. PEL 재처리 대기.");
 				} else {
 					log.info("[RecruitmentConsumer] 다른 컨슈머가 현재 처리 중입니다. (Skip)");
 				}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #266 

## 🔁 작업 내용
- 기존 : 잡코리아 게시글 식별값인 postId를 기반으로, DB Query를 날려 존재 여부를 확인함으로써 멱등 처리를 보장합니다.
- 개선 : postId를 락 키로 사용하여 불필요한 커넥션 점유 없이 멱등 처리를 보장합니다.

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 입력값 검증 및 JSON 파싱 오류 처리를 추가하여 처리 안정성을 강화했습니다.
  * 분산 잠금 도입으로 중복 처리를 방지하고 데이터 일관성을 개선했습니다.
  * 오류 발생 시 재시도 카운터 및 처리 흐름을 정비해 실패 복구와 재시도를 안정화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->